### PR TITLE
Shell Completion: Implement completion subcommand structure

### DIFF
--- a/crates/dotfilet-cli/src/commands/completion.rs
+++ b/crates/dotfilet-cli/src/commands/completion.rs
@@ -1,0 +1,73 @@
+use std::env;
+use std::io;
+
+use clap::{CommandFactory};
+use clap_complete::{generate, Shell};
+
+use crate::command::*;
+
+#[derive(Parser)]
+/// Generate shell completion scripts
+pub(crate) struct CompletionCommand {
+    /// Shell to generate completion for
+    #[arg(value_enum)]
+    pub(crate) shell: Option<SupportedShell>,
+}
+
+#[derive(clap::ValueEnum, Clone, Debug)]
+pub(crate) enum SupportedShell {
+    Bash,
+    Zsh,
+    Fish,
+}
+
+impl From<SupportedShell> for Shell {
+    fn from(shell: SupportedShell) -> Self {
+        match shell {
+            SupportedShell::Bash => Shell::Bash,
+            SupportedShell::Zsh => Shell::Zsh,
+            SupportedShell::Fish => Shell::Fish,
+        }
+    }
+}
+
+impl CompletionCommand {
+    pub(crate) fn execute(self) {
+        let shell = match self.shell {
+            Some(shell) => shell,
+            None => match detect_shell() {
+                Ok(shell) => shell,
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    std::process::exit(1);
+                }
+            },
+        };
+
+        let mut app = crate::commands::RootCommand::command();
+        let shell: Shell = shell.into();
+        
+        generate(shell, &mut app, "dotfilet", &mut io::stdout());
+    }
+}
+
+fn detect_shell() -> Result<SupportedShell, String> {
+    let shell_var = env::var("SHELL").map_err(|_| {
+        "Unable to detect shell: $SHELL environment variable is not set. Please specify a shell explicitly."
+    })?;
+
+    let shell_name = shell_var
+        .split('/')
+        .last()
+        .ok_or("Invalid $SHELL environment variable")?;
+
+    match shell_name {
+        "bash" => Ok(SupportedShell::Bash),
+        "zsh" => Ok(SupportedShell::Zsh),
+        "fish" => Ok(SupportedShell::Fish),
+        _ => Err(format!(
+            "Unsupported shell: {}. Supported shells are: bash, zsh, fish",
+            shell_name
+        )),
+    }
+}

--- a/crates/dotfilet-cli/src/commands/mod.rs
+++ b/crates/dotfilet-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod agent;
 pub(crate) mod apply;
+pub(crate) mod completion;
 pub(crate) mod diff;
 pub(crate) mod init;
 
@@ -34,6 +35,7 @@ pub(crate) enum Commands {
     Diff(diff::DiffCommand),
     Apply(apply::ApplyCommand),
     Agent(agent::AgentCommand),
+    Completion(completion::CompletionCommand),
 }
 
 impl Commands {
@@ -43,6 +45,7 @@ impl Commands {
             Commands::Diff(cmd) => cmd.execute(),
             Commands::Apply(cmd) => cmd.execute(),
             Commands::Agent(cmd) => cmd.execute(),
+            Commands::Completion(cmd) => cmd.execute(),
         }
     }
 }


### PR DESCRIPTION
[Closes #74]

## Description

Implements the basic `completion` subcommand structure in the CLI, including argument parsing and shell type validation. This establishes the foundation for completion script generation as specified in the task requirements.

## Changes Made

- Added `completion` subcommand to `Commands` enum in `crates/dotfilet-cli/src/commands/mod.rs`
- Created `completion.rs` with shell argument parsing and validation using clap derives
- Implemented `SupportedShell` enum supporting bash, zsh, and fish shells
- Added shell detection logic using `$SHELL` environment variable when no shell is specified  
- Integrated with existing clap derive macros and command structure patterns
- Added comprehensive error handling for unsupported shell types and missing environment variables
- Used `clap_complete` crate integration to generate actual completion scripts to stdout

## Acceptance Criteria & Testing

- [x] `completion` subcommand added to `Commands` enum in `crates/dotfilet-cli/src/commands/mod.rs`
- [x] Shell parameter accepts `bash`, `zsh`, and `fish` as valid options
- [x] Shell detection logic implemented for when no shell is specified
- [x] Basic command structure handles `dotfilet completion <shell>` syntax
- [x] Integration with existing clap derive macros maintained
- [x] Error handling for unsupported shell types

### Manual Testing Performed

- [x] `dotfilet completion --help` shows correct usage and options
- [x] `dotfilet completion bash` generates bash completion script
- [x] `dotfilet completion zsh` generates zsh completion script  
- [x] `dotfilet completion fish` generates fish completion script
- [x] `dotfilet completion` (no args) detects shell from `$SHELL` environment variable
- [x] Error handling for unsupported shells (tcsh, etc.) works correctly
- [x] Error handling for missing `$SHELL` environment variable works correctly
- [x] Clap validation rejects invalid shell arguments (powershell, etc.)

## Notes

This PR establishes the basic command structure required for shell completion. The generated completion scripts already include all existing dotfilet commands and options (init, diff, apply, agent with their respective subcommands and flags) through clap_complete's automatic parsing of the command structure.

The implementation follows the existing codebase patterns:
- Uses the same module structure as other commands (agent, init, etc.)
- Integrates with the existing `Commands` enum and execution pattern  
- Maintains compatibility with `postprocess_dotfilet_command()` extensions
- Uses consistent error handling and user experience patterns

Next task (#75) will focus on the specific completion script generation implementation details.