### PR TITLE
Shell Completion: Use clap_complete for shell detection and support all shells

### DIFF
--- a/crates/dotfilet-cli/src/commands/completion.rs
+++ b/crates/dotfilet-cli/src/commands/completion.rs
@@ -8,7 +8,7 @@ use crate::command::*;
 #[derive(Parser)]
 /// Generate shell completion scripts
 pub(crate) struct CompletionCommand {
-    /// Shell to generate completion for
+    /// Shell to generate completion for (detected automatically)
     #[arg(value_enum)]
     pub(crate) shell: Option<SupportedShell>,
 }

--- a/crates/dotfilet-cli/src/commands/completion.rs
+++ b/crates/dotfilet-cli/src/commands/completion.rs
@@ -16,16 +16,20 @@ pub(crate) struct CompletionCommand {
 #[derive(clap::ValueEnum, Clone, Debug)]
 pub(crate) enum SupportedShell {
     Bash,
-    Zsh,
+    Elvish,
     Fish,
+    PowerShell,
+    Zsh,
 }
 
 impl From<SupportedShell> for Shell {
     fn from(shell: SupportedShell) -> Self {
         match shell {
             SupportedShell::Bash => Shell::Bash,
-            SupportedShell::Zsh => Shell::Zsh,
+            SupportedShell::Elvish => Shell::Elvish,
             SupportedShell::Fish => Shell::Fish,
+            SupportedShell::PowerShell => Shell::PowerShell,
+            SupportedShell::Zsh => Shell::Zsh,
         }
     }
 }
@@ -36,8 +40,10 @@ impl TryFrom<Shell> for SupportedShell {
     fn try_from(shell: Shell) -> Result<Self, Self::Error> {
         match shell {
             Shell::Bash => Ok(SupportedShell::Bash),
-            Shell::Zsh => Ok(SupportedShell::Zsh),
+            Shell::Elvish => Ok(SupportedShell::Elvish),
             Shell::Fish => Ok(SupportedShell::Fish),
+            Shell::PowerShell => Ok(SupportedShell::PowerShell),
+            Shell::Zsh => Ok(SupportedShell::Zsh),
             _ => Err(format!("Unsupported shell: {:?}", shell)),
         }
     }

--- a/crates/dotfilet-cli/src/commands/completion.rs
+++ b/crates/dotfilet-cli/src/commands/completion.rs
@@ -18,6 +18,7 @@ pub(crate) enum SupportedShell {
     Bash,
     Elvish,
     Fish,
+    #[value(name = "powershell")]
     PowerShell,
     Zsh,
 }


### PR DESCRIPTION
[Closes #84]

## Description

This PR refactors the shell detection logic in the `completion` command to use `clap_complete::Shell::from_env()` instead of a custom implementation. It also extends the `SupportedShell` enum to include all shells supported by `clap_complete::Shell` (Bash, Elvish, Fish, PowerShell, Zsh).

## Changes Made

- Removed custom `detect_shell` function.
- Updated `CompletionCommand::execute` to use `clap_complete::Shell::from_env()` for shell detection.
- Expanded `SupportedShell` enum to include Elvish, PowerShell, and Zsh.
- Updated `From<SupportedShell> for Shell` and `TryFrom<Shell> for SupportedShell` implementations.
- Annotated `PowerShell` variant in `SupportedShell` to be recognized as "powershell" by clap.

## Acceptance Criteria & Testing

- [x] The `detect_shell` function is removed from `completion.rs`.
- [x] `clap_complete::Shell::from_env()` is used to detect the shell when no shell is specified.
- [x] The behavior of the `completion` command remains the same.
- [x] `SupportedShell` enum includes all shells supported by `clap_complete::Shell`.
- [x] The code compiles successfully.
- [x] `dotfilet completion powershell` generates the PowerShell completion script.

## Notes

This PR addresses the task of using `clap_complete`'s built-in shell detection and extends support to all shells provided by `clap_complete`.
